### PR TITLE
Fix mixed tabs and spaces in yaml example in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,7 +170,7 @@ jobs:
     name: Second Bench Job
     runs-on: ubuntu-latest
     steps:
-			- uses: actions/checkout@v2
+      - uses: actions/checkout@v2
       - run: ./benchmark.sh
       - uses: actions/upload-artifact@v2
         with:


### PR DESCRIPTION
By default GitHub shows a red box indicating a parser error when yaml is indented with tabs. This is in line with the YAML Specification, which lists that tabs are [invalid if used for indentation](https://yaml.org/spec/1.2/spec.html#id2777534).

This PR resolves that error by converting the tabs to spaces.